### PR TITLE
Add destructive flag to install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,9 @@ Configuration can be set by passing specific options to other commands.
   the `--strip-dot-git` option to the `install` command. It can be unset at the
   local level by passing the `--no-strip-dot-git` option.
 
+Note that the directories will be purged if you run librarian-ansible with the
+--clean or --destructive flags.
+
 ## Contributing
 
 1. Fork it ( http://github.com/bcoe/librarian-ansible/fork )

--- a/lib/librarian/ansible.rb
+++ b/lib/librarian/ansible.rb
@@ -1,1 +1,2 @@
 require 'librarian/ansible/extension'
+require 'librarian/action/install'

--- a/lib/librarian/ansible/action.rb
+++ b/lib/librarian/ansible/action.rb
@@ -1,0 +1,1 @@
+require "librarian/ansible/action/install"

--- a/lib/librarian/ansible/action/install.rb
+++ b/lib/librarian/ansible/action/install.rb
@@ -1,0 +1,22 @@
+require 'librarian/action/install'
+
+module Librarian
+  module Ansible
+    module Action
+      class Install < Librarian::Action::Install
+
+        private
+
+        def create_install_path
+          install_path.rmtree if install_path.exist? && destructive?
+          install_path.mkpath
+        end
+
+        def destructive?
+          environment.config_db.local['destructive'] == 'true'
+        end
+
+      end
+    end
+  end
+end

--- a/lib/librarian/ansible/extension.rb
+++ b/lib/librarian/ansible/extension.rb
@@ -1,4 +1,5 @@
 require 'librarian/ansible/environment'
+require 'librarian/action/base'
 
 module Librarian
   module Ansible

--- a/lib/librarian/ansible/version.rb
+++ b/lib/librarian/ansible/version.rb
@@ -1,5 +1,5 @@
 module Librarian
   module Ansible
-    VERSION = "1.0.6"
+    VERSION = "1.0.7"
   end
 end

--- a/spec/integration/ansible/source/git_spec.rb
+++ b/spec/integration/ansible/source/git_spec.rb
@@ -81,12 +81,12 @@ module Librarian
 
             context "the resolve" do
               it "should not raise an exception" do
-                expect { Action::Resolve.new(env).run }.to_not raise_error
+                expect { Librarian::Action::Resolve.new(env).run }.to_not raise_error
               end
             end
 
             context "the results" do
-              before { Action::Resolve.new(env).run }
+              before { Librarian::Action::Resolve.new(env).run }
 
               it "should create the lockfile" do
                 repo_path.join("Ansiblefile.lock").should exist
@@ -110,7 +110,7 @@ module Librarian
               ANSIBLEFILE
               repo_path.join("Ansiblefile").open("wb") { |f| f.write(ansiblefile) }
 
-              Action::Resolve.new(env).run
+              Librarian::Action::Resolve.new(env).run
             end
 
             context "the install" do
@@ -148,7 +148,7 @@ module Librarian
               ANSIBLEFILE
               repo_path.join("Ansiblefile").open("wb") { |f| f.write(ansiblefile) }
 
-              Action::Resolve.new(env).run
+              Librarian::Action::Resolve.new(env).run
               repo_path.join("tmp").rmtree if repo_path.join("tmp").exist?
             end
 
@@ -210,7 +210,7 @@ module Librarian
             end
 
             it "should not resolve" do
-              expect{ Action::Resolve.new(env).run }.to raise_error
+              expect{ Librarian::Action::Resolve.new(env).run }.to raise_error
             end
           end
 
@@ -230,7 +230,7 @@ module Librarian
             end
 
             it "should not resolve" do
-              expect{ Action::Resolve.new(env).run }.to raise_error
+              expect{ Librarian::Action::Resolve.new(env).run }.to raise_error
             end
           end
 
@@ -251,12 +251,12 @@ module Librarian
 
             context "the resolve" do
               it "should not raise an exception" do
-                expect { Action::Resolve.new(env).run }.to_not raise_error
+                expect { Librarian::Action::Resolve.new(env).run }.to_not raise_error
               end
             end
 
             context "the results" do
-              before { Action::Resolve.new(env).run }
+              before { Librarian::Action::Resolve.new(env).run }
 
               it "should create the lockfile" do
                 repo_path.join("Ansiblefile.lock").should exist
@@ -307,7 +307,7 @@ module Librarian
                 :ref => "some-branch"
             ANSIBLEFILE
             repo_path.join("Ansiblefile").open("wb") { |f| f.write(ansiblefile) }
-            Action::Resolve.new(env).run
+            Librarian::Action::Resolve.new(env).run
 
             # change the upstream copy of that branch: we expect to be able to pull the latest
             # when we re-resolve
@@ -326,7 +326,7 @@ module Librarian
 
           context "when updating not a role from that source" do
             before do
-              Action::Update.new(env).run
+              Librarian::Action::Update.new(env).run
             end
 
             it "should pull the tip from upstream" do
@@ -341,7 +341,7 @@ module Librarian
 
           context "when updating a role from that source" do
             before do
-              Action::Update.new(env, :names => %w(sample)).run
+              Librarian::Action::Update.new(env, :names => %w(sample)).run
             end
 
             it "should pull the tip from upstream" do


### PR DESCRIPTION
Without destructive flag, the install command recreates the install_path folder thus all local ansible playbooks (which are not installed via librarian-ansible) are getting lost.