### PR TITLE
Fix broken Galaxy API package lookup pagination

### DIFF
--- a/lib/librarian/ansible/source/galaxy.rb
+++ b/lib/librarian/ansible/source/galaxy.rb
@@ -54,13 +54,17 @@ module Librarian
                 raise Error, 'Could not read package from galaxy API.'
               else
                 json = JSON.parse(response.body)
+
+                break if json['results'].nil?
+
                 package = json['results'].find do |r|
                   r['namespace'] == username &&
                     r['name'] == name
                 end
                 return package if package
+
+                break unless json['next']
                 url = "#{@@galaxy_api}/#{json['next']}"
-                break unless url
               end
             end
           end


### PR DESCRIPTION
Prior to this fix, pagination for package lookup is broken. I have a package that I use, `george.shuklin.reboot-if-needed-for-upgrade`. Librarian::Ansible::Source::Galaxy.lookup_package fails for this on the second pass. The first result is against

```
roles/?name=shuklin.reboot-if-needed-for-upgrade&format=json
```

which returns:

```json
    {
      "count": 0,
      "cur_page": 1,
      "next": null,
      "next_link": null,
      "num_pages": 1,
      "previous": null,
      "previous_link": null,
      "results": []
    }
```

Because `json['next']` is `null`, the next loop around hits the base URL, and does not break because the test is against `url`, not against the value of `json['next']`.

This PR provides two guards against this error:

1.  If there are no results, just break. There won't be a `next` field.
2.  If there is no `next` field, break.