### PR TITLE
handle empty manifest

### DIFF
--- a/lib/librarian/ansible/manifest_reader.rb
+++ b/lib/librarian/ansible/manifest_reader.rb
@@ -15,7 +15,9 @@ module Librarian
       def read_manifest(name, manifest_path)
         if [".yml", ".yaml"].include?(manifest_path.extname)
           YAML.load(binread(manifest_path)).tap do |m|
-            m["dependencies"] = []
+            if m.is_a?(Hash)
+              m["dependencies"] = []
+            end
           end
         end
       end

--- a/lib/librarian/ansible/source/local.rb
+++ b/lib/librarian/ansible/source/local.rb
@@ -26,11 +26,17 @@ module Librarian
         end
 
         def fetch_version(name, extra)
-          manifest_data(name)["version"] || "0.0.0"
+          if manifest_data(name).is_a?(Hash) and manifest_data(name).has_key?("version")
+            manifest_data(name)["version"]
+          else
+            "0.0.0"
+          end
         end
 
         def fetch_dependencies(name, version, extra)
-          manifest_data(name)["dependencies"]
+          if manifest_data(name).is_a?(Hash) and manifest_data(name).has_key?("dependencies")
+            manifest_data(name)["dependencies"]
+          end
         end
 
       private


### PR DESCRIPTION
When a meta/main.yml file exists, but without dependencies declared, librarian crash. This path will handle gracefully the missing attributes and will go on.